### PR TITLE
Add method value now optional

### DIFF
--- a/docs/ObjectReference/Methods/Add.md
+++ b/docs/ObjectReference/Methods/Add.md
@@ -12,7 +12,7 @@ Part               | Description
 :---               | :---
 _object_           | Required. Always the name of a **Dictionary** object.
 _Key_              | Required. They key associated with the item being added.
-_Val_              | Required. The value associated with the key being added.
+_[Val]_            | Optional. The value associated with the key being added.
 
 ## Remarks
 

--- a/src/Dictionary.cls
+++ b/src/Dictionary.cls
@@ -184,7 +184,7 @@ End Sub
 
 ' Methods
 '-------------------------------------------------------------------------------
-Public Sub Add(Key As Variant, val As Variant)
+Public Sub Add(Key As Variant, Optional val As Variant = Nothing)
 Attribute Add.VB_Description = "Adds a key and value pair to the dictionary."
 '   Adds a key and value pair to the dictionary.
 '


### PR DESCRIPTION
The basic `.Add` method has been changed so the `val` argument is optional with `Nothing` as the default. This is an improvement as you may wish to use the Dictionary to track keys only.