### PR TITLE
Improvements

### DIFF
--- a/src/Dictionary.cls
+++ b/src/Dictionary.cls
@@ -35,6 +35,11 @@ Option Explicit
 '   Class: Dictionary
 '   A wrapper that extends Scripting.Dictionary functionality.
 '-------------------------------------------------------------------------------
+'   Exceptions thrown by the Scripting.Dictionary bubble up to the Dictionary
+'   but do not seem to go further than that, even if you have your own error
+'   handling. That's why you'll see exception handling in here that rethrows the
+'   exception. This is so that it can be caught by the calling method.
+'       #JustVbaThings
 
 ' Enums
 '-------------------------------------------------------------------------------
@@ -100,15 +105,27 @@ Public Property Let Item(Key As Variant, val As Variant)
 Attribute Item.VB_UserMemId = 0
 Attribute Item.VB_Description = "Sets or returns an item for a specified key in a Dictionary object."
 '   Sets or returns an item for a specified key in a Dictionary object.
-    If mOptionNoItemFail Then On Error Resume Next
+Try:
+    On Error GoTo Catch
     mBaseDict.Item(Key) = val
     If Err = 0 Then MetaTrackingAdd val
+    Exit Property
+
+Catch:
+    If mOptionNoItemFail Then Exit Property
+    Err.Raise Err
 End Property
 
 Public Property Set Item(Key As Variant, val As Variant)
-    If mOptionNoItemFail Then On Error Resume Next
+Try:
+    On Error GoTo Catch
     Set mBaseDict.Item(Key) = val
-    If Err = 0 Then MetaTrackingAdd val
+    MetaTrackingAdd val
+    Exit Property
+
+Catch:
+    If mOptionNoItemFail Then Exit Property
+    Err.Raise Err
 End Property
 
 Public Property Get Item(Key As Variant) As Variant
@@ -195,18 +212,24 @@ Attribute Add.VB_Description = "Adds a key and value pair to the dictionary."
 '       Key: The key to add the value to.
 '       val: The value to add.
 '
-    If mOptionNoItemFail Then On Error Resume Next
+    On Error Resume Next
     mBaseDict.Add Key, val
-    
-    If Err = 457 Then
-        If IsObject(val) Then
-            Set Item(Key) = val
-        Else
-            Item(Key) = val
-        End If
-    Else
-        MetaTrackingAdd val
-    End If
+
+    Select Case True
+        Case Is = Err = 457 And mOptionNoItemFail
+            If IsObject(val) Then
+                Set Item(Key) = val
+            Else
+                Item(Key) = val
+            End If
+        Case Is = Err = 457
+            Err.Raise vbObjectError + 457, "Dictionary", _
+                Key & " is already associated with the dictionary."
+        Case Is = Err <> 0
+            Err.Raise Err
+        Case Else
+            MetaTrackingAdd val
+    End Select
 End Sub
 
 Public Sub Remove(Key As Variant)
@@ -441,14 +464,14 @@ Attribute NArrayDimensions.VB_Description = "Returns the number of dimensions fo
 '
     
 '   Test array dimensions until exception raised
-    On Error GoTo Result
+    On Error GoTo Finally
     Dim i As Long
     Do
         i = i + 1
         NArrayDimensions = UBound(arr, i)
     Loop
     
-Result:
+Finally:
 '   Expect to catch a Type mismatch exception.
 '   Expect to catch a Subscript out of range exception.
     If Err = 13 Or Err = 9 Then NArrayDimensions = i - 1 Else Err.Raise Err

--- a/test/DictionaryTests.bas
+++ b/test/DictionaryTests.bas
@@ -577,7 +577,7 @@ Attribute TestDictionary_NoOptionNoItemFailThrows.VB_Description = "Without Opti
     d.Add INPKEYA, INPVALB
 
 '   Assert
-    If tr.AssertRaised(DUPLICATEKEYEX) Then GoTo Finally
+    If tr.AssertRaised(vbObjectError + DUPLICATEKEYEX) Then GoTo Finally
     On Error GoTo 0
 
     If tr.AssertAreEqual(1, d.Count, "count") Then GoTo Finally

--- a/test/DictionaryTests.bas
+++ b/test/DictionaryTests.bas
@@ -50,7 +50,8 @@ End Sub
 
 Sub RunSingle()
     Dim tr As TestResult
-    Set tr = TestDictionary_ItemReturnsItem()
+    Set tr = TestDictionary_AddKeyOnly()
+    tr.Name = "TestDictionary_AddKeyOnly"
     Debug.Print tr.ToString
 End Sub
 
@@ -127,6 +128,32 @@ Attribute TestDictionary_Add.VB_Description = "Add an item to the dictionary."
 Finally:
     On Error GoTo 0
     Set TestDictionary_Add = tr
+End Function
+
+Private Function TestDictionary_AddKeyOnly() As TestResult
+Attribute TestDictionary_AddKeyOnly.VB_Description = "Adding a key with no value to the dictionary."
+'   Adding a key with no value to the dictionary.
+    Dim tr As New TestResult
+
+'   Arrange
+    Const ADDKEY As String = "K"
+    Dim d As New Dictionary
+
+'   Act
+    On Error Resume Next
+    d.Add ADDKEY
+
+'   Assert
+    If tr.AssertNoException() Then GoTo Finally
+    On Error GoTo 0
+
+    If tr.AssertAreEqual(1, d.Count) Then GoTo Finally
+    If tr.AssertIsTrue(d.Exists(ADDKEY), "Key exists") Then GoTo Finally
+    If tr.AssertAreEqual(Nothing, d(ADDKEY)) Then GoTo Finally
+
+Finally:
+    On Error GoTo 0
+    Set TestDictionary_AddKeyOnly = tr
 End Function
 
 Private Function TestDictionary_AddBulkColMode() As TestResult

--- a/test/TestResult.cls
+++ b/test/TestResult.cls
@@ -66,10 +66,31 @@ Attribute AssertAreEqual.VB_Description = "Asserts expected is equal to actual."
 '   Returns:
 '       False if the assertion passed.
 '
-    If expectedVal <> actualVal Then
-        Failed = True
-        SetExpectedActualMessage CStr(expectedVal), CStr(actualVal), forVal
-    End If
+    Select Case True
+'       Only one value is an object.
+        Case Is = IsObject(expectedVal) Xor IsObject(actualVal):
+            Failed = True
+            SetExpectedActualMessage _
+                TypeName(expectedVal), _
+                TypeName(actualVal), _
+                forVal
+'       Both values are objects (test reference).
+        Case Is = IsObject(expectedVal) And IsObject(actualVal):
+            If Not expectedVal Is actualVal Then
+                Failed = True
+                SetExpectedActualMessage _
+                    TypeName(expectedVal), _
+                    TypeName(actualVal), _
+                    forVal
+            End If
+'       Neither values are objects.            
+        Case Else:
+            If expectedVal <> actualVal Then
+                Failed = True
+                SetExpectedActualMessage CStr(expectedVal), CStr(actualVal), forVal
+            End If
+    End Select
+
     AssertAreEqual = Failed
 End Function
 
@@ -108,7 +129,7 @@ Attribute AssertIsTrue.VB_Description = "Asserts the value is true."
 '
     If Not val Then
         Failed = True
-        Message = "Failed " & ctx
+        Message = "Is not true [" & ctx & "]"
     End If
 
     AssertIsTrue = Failed


### PR DESCRIPTION
Adds a test for adding a key with no value and improves the error handling. This was required because exceptions thrown by the underlying Scripting.Dictionary throws its toys out of the pram even when catching in a parent frame, e.g.:

```vb
On Error Resume Next
Set d = New Dictionary
d.Add "x"
d.Add "x"
```

Duplicate key error was not caught, instead must be caught by Dictionary object and rethrown.